### PR TITLE
Expose bypass writer for uilive

### DIFF
--- a/example/bypass/bypass.go
+++ b/example/bypass/bypass.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gosuri/uiprogress"
+)
+
+func main() {
+	waitTime := time.Millisecond * 200
+	p := uiprogress.New()
+	p.Start()
+
+	var wg sync.WaitGroup
+
+	bar1 := p.AddBar(20).AppendCompleted().PrependElapsed()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for bar1.Incr() {
+			time.Sleep(waitTime)
+		}
+		fmt.Fprintln(p.Bypass(), "Bar1 finished")
+	}()
+
+	bar2 := p.AddBar(40).AppendCompleted().PrependElapsed()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for bar2.Incr() {
+			time.Sleep(waitTime)
+		}
+		fmt.Fprintln(p.Bypass(), "Bar2 finished")
+	}()
+
+	time.Sleep(time.Second)
+	bar3 := p.AddBar(20).PrependElapsed().AppendCompleted()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for bar3.Incr() {
+			time.Sleep(waitTime)
+		}
+		fmt.Fprintln(p.Bypass(), "Bar3 finished")
+	}()
+
+	wg.Wait()
+}

--- a/progress.go
+++ b/progress.go
@@ -115,3 +115,8 @@ func (p *Progress) Stop() {
 	close(p.stopChan)
 	p.stopChan = nil
 }
+
+// Bypass returns a writer which allows non-buffered data to be written to the underlying output
+func (p *Progress) Bypass() io.Writer {
+	return p.lw.Bypass()
+}


### PR DESCRIPTION
Allow log output (for example) to be written without being overwritten by the next
progress bar refresh.

See gosuri/uilive#6 for more details
