### PR TITLE
Using time.Ticker for running stoppable listener. Fix edge case where flush happens after the listener is stopped.

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -91,8 +91,12 @@ func (p *Progress) Listen() {
 		select {
 		case <-p.ticker.C:
 			p.mtx.RLock()
-			p.print()
-			p.lw.Flush()
+
+			if p.ticker != nil {
+				p.print()
+				p.lw.Flush()
+			}
+
 			p.mtx.RUnlock()
 		case <-p.tdone:
 			p.ticker.Stop()

--- a/progress.go
+++ b/progress.go
@@ -85,11 +85,12 @@ func (p *Progress) AddBar(total int) *Bar {
 
 // Listen listens for updates and renders the progress bars
 func (p *Progress) Listen() {
+	var tickChan = p.ticker.C
 	p.lw.Out = p.Out
 
 	for {
 		select {
-		case <-p.ticker.C:
+		case <-tickChan:
 			p.mtx.RLock()
 
 			if p.ticker != nil {

--- a/progress.go
+++ b/progress.go
@@ -99,9 +99,11 @@ func (p *Progress) Listen() {
 
 			p.mtx.RUnlock()
 		case <-p.tdone:
-			p.ticker.Stop()
-			p.ticker = nil
-			return
+			if p.ticker != nil {
+				p.ticker.Stop()
+				p.ticker = nil
+				return
+			}
 		}
 	}
 }

--- a/progress.go
+++ b/progress.go
@@ -117,6 +117,7 @@ func (p *Progress) Start() {
 func (p *Progress) Stop() {
 	p.mtx.Lock()
 	p.ticker.Stop()
+	p.ticker = nil
 	p.print()
 	p.lw.Flush()
 	p.mtx.Unlock()

--- a/progress.go
+++ b/progress.go
@@ -33,9 +33,9 @@ type Progress struct {
 	// RefreshInterval in the time duration to wait for refreshing the output
 	RefreshInterval time.Duration
 
-	lw       *uilive.Writer
-	stopChan chan struct{}
-	mtx      *sync.RWMutex
+	lw     *uilive.Writer
+	ticker *time.Ticker
+	mtx    *sync.RWMutex
 }
 
 // New returns a new progress bar with defaults
@@ -46,9 +46,8 @@ func New() *Progress {
 		Bars:            make([]*Bar, 0),
 		RefreshInterval: RefreshInterval,
 
-		lw:       uilive.New(),
-		stopChan: make(chan struct{}),
-		mtx:      &sync.RWMutex{},
+		lw:  uilive.New(),
+		mtx: &sync.RWMutex{},
 	}
 }
 
@@ -86,34 +85,41 @@ func (p *Progress) AddBar(total int) *Bar {
 // Listen listens for updates and renders the progress bars
 func (p *Progress) Listen() {
 	p.lw.Out = p.Out
-	for {
-		select {
-		case <-p.stopChan:
-			return
-		default:
-			time.Sleep(p.RefreshInterval)
+
+	go func() {
+		for _ = range p.ticker.C {
 			p.mtx.RLock()
-			for _, bar := range p.Bars {
-				fmt.Fprintln(p.lw, bar.String())
-			}
+			p.print()
 			p.lw.Flush()
 			p.mtx.RUnlock()
 		}
+	}()
+}
+
+func (p *Progress) print() {
+	for _, bar := range p.Bars {
+		fmt.Fprintln(p.lw, bar.String())
 	}
 }
 
 // Start starts the rendering the progress of progress bars. It listens for updates using `bar.Set(n)` and new bars when added using `AddBar`
 func (p *Progress) Start() {
-	if p.stopChan == nil {
-		p.stopChan = make(chan struct{})
+	p.mtx.Lock()
+	if p.ticker == nil {
+		p.ticker = time.NewTicker(RefreshInterval)
 	}
+	p.mtx.Unlock()
+
 	go p.Listen()
 }
 
 // Stop stops listening
 func (p *Progress) Stop() {
-	close(p.stopChan)
-	p.stopChan = nil
+	p.mtx.Lock()
+	p.ticker.Stop()
+	p.print()
+	p.lw.Flush()
+	p.mtx.Unlock()
 }
 
 // Bypass returns a writer which allows non-buffered data to be written to the underlying output

--- a/progress_test.go
+++ b/progress_test.go
@@ -35,9 +35,6 @@ func TestStoppingPrintout(t *testing.T) {
 	progress.Stop()
 	fmt.Fprintf(buffer, "foo")
 
-	// give some time to see if any changes are made after Stop() is called
-	time.Sleep(time.Millisecond * 20)
-
 	var wantSuffix = "[======================================================>-------------]\nfoo"
 
 	if !strings.HasSuffix(buffer.String(), wantSuffix) {

--- a/progress_test.go
+++ b/progress_test.go
@@ -1,0 +1,46 @@
+package uiprogress
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStoppingPrintout(t *testing.T) {
+	progress := New()
+	progress.RefreshInterval = time.Millisecond * 10
+	var buffer = &bytes.Buffer{}
+	progress.Out = buffer
+	bar := progress.AddBar(100)
+	progress.Start()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		for i := 0; i <= 80; i = i + 10 {
+			bar.Set(i)
+			time.Sleep(time.Millisecond * 5)
+		}
+
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	progress.Stop()
+	fmt.Fprintf(buffer, "foo")
+
+	// give some time to see if any changes are made after Stop() is called
+	time.Sleep(time.Millisecond * 20)
+
+	var wantSuffix = "[======================================================>-------------]\nfoo"
+
+	if !strings.HasSuffix(buffer.String(), wantSuffix) {
+		t.Errorf("Content that should be printed after stop not appearing on buffer.")
+	}
+}


### PR DESCRIPTION
This should close #18 and #20.

@mgurov, can you take a look at the changes I have made on top of your code (which I actually rebased), please?

https://github.com/gosuri/uilive/pull/7 is also needed.
