### PR TITLE
fix stop, stop block until really stopped

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -89,6 +89,7 @@ func (p *Progress) Listen() {
 	for {
 		select {
 		case <-p.stopChan:
+			p.stopChan = nil
 			return
 		default:
 			time.Sleep(p.RefreshInterval)
@@ -113,7 +114,11 @@ func (p *Progress) Start() {
 // Stop stops listening
 func (p *Progress) Stop() {
 	close(p.stopChan)
-	p.stopChan = nil
+	for {
+		if p.stopChan == nil {
+			return
+		}
+	}
 }
 
 // Bypass returns a writer which allows non-buffered data to be written to the underlying output


### PR DESCRIPTION
Hi,

using your package, i've found that calls to stop in Progress don't stop the go routine of Listen(), becouse the stopChan is set to nil.

reproduced here
https://play.golang.org/p/yDiCsMwWRj

by commenting p.stopChan = nil, it's fixed

I also made call to stop blocking until the go routine is really stopped.

