### PR TITLE
Make RefreshInterval configurable and render bars one last time at Stop()

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -17,7 +17,7 @@ var Out = os.Stdout
 var RefreshInterval = time.Millisecond * 10
 
 // defaultProgress is the default progress
-var defaultProgress = New()
+var defaultProgress *Progress
 
 // Progress represents the container that renders progress bars
 type Progress struct {
@@ -54,21 +54,32 @@ func New() *Progress {
 
 // AddBar creates a new progress bar and adds it to the default progress container
 func AddBar(total int) *Bar {
+	if defaultProgress == nil {
+		defaultProgress = New()
+	}
 	return defaultProgress.AddBar(total)
 }
 
 // Start starts the rendering the progress of progress bars using the DefaultProgress. It listens for updates using `bar.Set(n)` and new bars when added using `AddBar`
 func Start() {
+	if defaultProgress == nil {
+		defaultProgress = New()
+	}
 	defaultProgress.Start()
 }
 
 // Stop stops listening
 func Stop() {
-	defaultProgress.Stop()
+	if defaultProgress != nil {
+		defaultProgress.Stop()
+	}
 }
 
 // Listen listens for updates and renders the progress bars
 func Listen() {
+	if defaultProgress == nil {
+		defaultProgress = New()
+	}
 	defaultProgress.Listen()
 }
 

--- a/progress.go
+++ b/progress.go
@@ -94,6 +94,16 @@ func (p *Progress) AddBar(total int) *Bar {
 	return bar
 }
 
+func (p *Progress) renderBars() {
+	p.mtx.RLock()
+	for _, bar := range p.Bars {
+		fmt.Fprintln(p.lw, bar.String())
+	}
+	p.lw.Flush()
+	p.mtx.RUnlock()
+
+}
+
 // Listen listens for updates and renders the progress bars
 func (p *Progress) Listen() {
 	p.lw.Out = p.Out
@@ -103,12 +113,7 @@ func (p *Progress) Listen() {
 			return
 		default:
 			time.Sleep(p.RefreshInterval)
-			p.mtx.RLock()
-			for _, bar := range p.Bars {
-				fmt.Fprintln(p.lw, bar.String())
-			}
-			p.lw.Flush()
-			p.mtx.RUnlock()
+			p.renderBars()
 		}
 	}
 }
@@ -125,6 +130,7 @@ func (p *Progress) Start() {
 func (p *Progress) Stop() {
 	close(p.stopChan)
 	p.stopChan = nil
+	p.renderBars()
 }
 
 // Bypass returns a writer which allows non-buffered data to be written to the underlying output


### PR DESCRIPTION
This pull request contains 2 patches.
- RefreshInterval was not considered because the default bar was already created before the user could set this public variable. Setting the variable and then calling Start() is  now possible.
- When a program exited before uiprogress had a change to render the output, it looked like bars did not finish. So far there was a workaround by sleeping, but this should not be necessary.

Regards, rck