### PR TITLE
Make time elapsed work when using Set()

### DIFF
--- a/bar.go
+++ b/bar.go
@@ -95,6 +95,10 @@ func (b *Bar) Set(n int) error {
 	if n > b.Total {
 		return ErrMaxCurrentReached
 	}
+	if b.TimeStarted.IsZero() {
+		b.TimeStarted = time.Now()
+	}
+	b.timeElapsed = time.Since(b.TimeStarted)
 	b.current = n
 	return nil
 }
@@ -108,8 +112,7 @@ func (b *Bar) Incr() bool {
 	if n > b.Total {
 		return false
 	}
-	var t time.Time
-	if b.TimeStarted == t {
+	if b.TimeStarted.IsZero() {
 		b.TimeStarted = time.Now()
 	}
 	b.timeElapsed = time.Since(b.TimeStarted)


### PR DESCRIPTION
Currently, the variables needed to show time elapsed are only set when using `Incr()`. This PR makes it also work when using `Set()`.