### PR TITLE
Use the correct uilive instance

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -51,7 +51,7 @@ func New() *Progress {
 		RefreshInterval: RefreshInterval,
 
 		tdone: make(chan bool),
-		lw:    uilive.New(),
+		lw:    lw,
 		mtx:   &sync.RWMutex{},
 	}
 }


### PR DESCRIPTION
The code was using a new instance of uilive and not the one with the correct "Out" instance. This means even if you set uiprogress.Out to dev null you'll still get progress bars.

This PR uses the correct instance.

Thanks for the library!