### PR TITLE
Use already created uilive.Writer object.  Also add go mod support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/gosuri/uiprogress
+
+go 1.15
+
+require (
+	github.com/gosuri/uilive v0.0.4
+	github.com/mattn/go-isatty v0.0.12 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/gosuri/uilive v0.0.4 h1:hUEBpQDj8D8jXgtCdBu7sWsy5sbW/5GhuO8KBwJ2jyY=
+github.com/gosuri/uilive v0.0.4/go.mod h1:V/epo5LjjlDE5RJUcqx8dbw+zc93y5Ya3yg8tfZ74VI=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/progress.go
+++ b/progress.go
@@ -51,7 +51,7 @@ func New() *Progress {
 		RefreshInterval: RefreshInterval,
 
 		tdone: make(chan bool),
-		lw:    uilive.New(),
+		lw:    lw,
 		mtx:   &sync.RWMutex{},
 	}
 }


### PR DESCRIPTION
Bug prevents users from changing uiprogress.Out to os.Stderr or any other Writer
go mod support needed for golang 1.16 and newer