### PR TITLE
Update elapsed time when using Set

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,30 @@ wg.Wait()
 uiprogress.Stop()
 ```
 
+### `Set` counter and tracking progress of the external process
+
+You can use progress bar to track the progress of any external process, for example
+the process of execution of github actions workflow run. To get an accurate
+elapsed time use `.WithStartedAt(time)` to initialize starting time for the progress
+bar.
+
+```
+job, _ := FetchExternalJob() // request for external resource
+totalStepsCount := len(job.Steps)
+
+uiprogress.Start()
+bar := uiprogress.AddBar(totalStepsCount).WithStartedAt(job.StartedAt).AppendCompleted().PrependElapsed()
+for !job.IsCompleted {
+    // poll resource status
+    job, _ = FetchExternalJob()
+    // update progress
+    bar.Set(job.GetCurrentStepNumber())
+    // wait a second
+    time.Sleep(time.Second)
+}
+uiprogress.Stop()
+```
+
 ## Installation
 
 ```sh

--- a/bar.go
+++ b/bar.go
@@ -95,6 +95,8 @@ func (b *Bar) Set(n int) error {
 	if n > b.Total {
 		return ErrMaxCurrentReached
 	}
+
+	b.updateElapsed()
 	b.current = n
 	return nil
 }
@@ -108,13 +110,17 @@ func (b *Bar) Incr() bool {
 	if n > b.Total {
 		return false
 	}
+	b.updateElapsed()
+	b.current = n
+	return true
+}
+
+func (b *Bar) updateElapsed() {
 	var t time.Time
 	if b.TimeStarted == t {
 		b.TimeStarted = time.Now()
 	}
 	b.timeElapsed = time.Since(b.TimeStarted)
-	b.current = n
-	return true
 }
 
 // Current returns the current progress of the bar
@@ -169,6 +175,13 @@ func (b *Bar) PrependElapsed() *Bar {
 	b.PrependFunc(func(b *Bar) string {
 		return strutil.PadLeft(b.TimeElapsedString(), 5, ' ')
 	})
+	return b
+}
+
+// WithStartedAt initializes time of start for calculation of elapsed time
+func (b *Bar) WithStartedAt(t time.Time) *Bar {
+	b.TimeStarted = t
+	b.updateElapsed()
 	return b
 }
 


### PR DESCRIPTION
I have been using `uiprogress` to track the progress of a github action workflow run and noticed that when I use `Set` elapsed time is not being updated, leading to '---' being displayed at all times, so I had to ditch the use of `PrependElapsed` and used `AppendFunc` instead to implement the functionality.

The change I'm proposing should enable the use of `PrependElapsed` for the use case in question.